### PR TITLE
RemoveTasksの処理の最初にsortを追加

### DIFF
--- a/internal/entities/task/task_handler.go
+++ b/internal/entities/task/task_handler.go
@@ -1,7 +1,6 @@
 package task
 
 import (
-	"fmt"
 	"encoding/json"
 	"io/ioutil"
 	"os"

--- a/internal/entities/task/task_handler.go
+++ b/internal/entities/task/task_handler.go
@@ -1,10 +1,12 @@
 package task
 
 import (
+	"fmt"
 	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/google/uuid"
 )
@@ -161,6 +163,8 @@ func (h *Handler) RemoveTask(id int) {
 
 // RemoveTasks is a function that remove tasks matched the given uuids.
 func (h *Handler) RemoveTasks(ids []int) {
+	sort.Slice(ids, func(i, j int) bool { return i > j })
+
 	for i, id := range ids {
 		if id-i > len(h.tasks) {
 			continue


### PR DESCRIPTION
# チケット
#23 

# 概要
closeする際に昇順にidを指定しないと変なものが消えるバグがあった。
そのため、内部で強制的に昇順にする様にsortした。
