### PR TITLE
todo addの際のtオプションを撤廃

### DIFF
--- a/cmd/todo/main.go
+++ b/cmd/todo/main.go
@@ -61,7 +61,6 @@ func main() {
 				Usage:   "Add a task",
 				Action:  commands.Add,
 				Flags: []cli.Flag{
-					flagTask,
 					flagRemindTime,
 					flagReminder,
 				},

--- a/internal/commands/add.go
+++ b/internal/commands/add.go
@@ -19,6 +19,11 @@ func Add(c *cli.Context) error {
 		return err
 	}
 
+	at := c.Args().First()
+	if at == "" {
+		return fmt.Errorf("`$ todo add` need an argument what represents a task")
+	}
+
 	rt := c.String("remind_time")
 
 	if strings.HasPrefix(rt, "+") || strings.HasPrefix(rt, "now+") {
@@ -45,7 +50,7 @@ func Add(c *cli.Context) error {
 	}
 
 	t := &task.Task{
-		Task:       c.String("task"),
+		Task:       at,
 		RemindTime: d,
 		UUID:       uu.String(),
 		Reminder:   r,


### PR DESCRIPTION
# チケット
#42 

# 概要
todo add する際にタスクは必ず必要なため、tオプションは不要である。
tオプションを撤廃し
```
$ todo add hogehoge
```

とするようにした。
