### PR TITLE
refactor: add, modifyの時間周りの処理など

### DIFF
--- a/cmd/todo/main.go
+++ b/cmd/todo/main.go
@@ -42,8 +42,8 @@ func main() {
 		Required: true,
 	}
 	flagRemoveReminder := &cli.BoolFlag{
-		Name:     "remove-reminder",
-		Usage:    "remove reminder. this option overrides reminder option",
+		Name:  "remove-reminder",
+		Usage: "remove reminder. this option overrides reminder option",
 	}
 
 	app := &cli.App{

--- a/cmd/todo/main.go
+++ b/cmd/todo/main.go
@@ -41,6 +41,10 @@ func main() {
 		Usage:    "task's UUID",
 		Required: true,
 	}
+	flagRemoveReminder := &cli.BoolFlag{
+		Name:     "remove-reminder",
+		Usage:    "remove reminder. this option overrides reminder option",
+	}
 
 	app := &cli.App{
 		Name:                 "todo",
@@ -84,6 +88,7 @@ func main() {
 					flagTask,
 					flagRemindTime,
 					flagReminder,
+					flagRemoveReminder,
 				},
 			},
 			{

--- a/internal/commands/add.go
+++ b/internal/commands/add.go
@@ -23,7 +23,7 @@ func Add(c *cli.Context) error {
 
 	if strings.HasPrefix(rt, "+") || strings.HasPrefix(rt, "now+") {
 		rt = strings.Replace(rt, "now", "", 1)
-		rt, err = timestr.ModifyTime(rt, timestr.FormatTime(time.Now()))
+		rt, err = timestr.ModifyTime(rt, time.Now())
 		if err != nil {
 			return err
 		}

--- a/internal/commands/add.go
+++ b/internal/commands/add.go
@@ -2,11 +2,8 @@ package commands
 
 import (
 	"fmt"
-	"strings"
-	"time"
 
 	"github.com/dondakeshimo/todo-cli/internal/entities/task"
-	"github.com/dondakeshimo/todo-cli/internal/entities/timestr"
 	"github.com/dondakeshimo/todo-cli/pkg/scheduler"
 	"github.com/google/uuid"
 	"github.com/urfave/cli/v2"
@@ -19,17 +16,7 @@ func Add(c *cli.Context) error {
 		return err
 	}
 
-	rt := c.String("remind_time")
-
-	if strings.HasPrefix(rt, "+") || strings.HasPrefix(rt, "now+") {
-		rt = strings.Replace(rt, "now", "", 1)
-		rt, err = timestr.ModifyTime(rt, time.Now())
-		if err != nil {
-			return err
-		}
-	}
-
-	d, err := timestr.UnifyLayout(rt)
+	rt, err := arrangeRemindTime(c.String("remind_time"), "")
 	if err != nil {
 		return err
 	}
@@ -46,7 +33,7 @@ func Add(c *cli.Context) error {
 
 	t := &task.Task{
 		Task:       c.String("task"),
-		RemindTime: d,
+		RemindTime: rt,
 		UUID:       uu.String(),
 		Reminder:   r,
 	}

--- a/internal/commands/utils.go
+++ b/internal/commands/utils.go
@@ -1,0 +1,39 @@
+package commands
+
+import (
+	"strings"
+	"time"
+
+	"github.com/dondakeshimo/todo-cli/internal/entities/timestr"
+)
+
+func arrangeRemindTime(rt string, preRt string) (string, error) {
+	if rt == "" {
+		return preRt, nil
+	}
+
+	// when input layout is "task+1h3m" or "task-1h3m"
+	if preRt != "" && strings.HasPrefix(rt, "task") {
+		rt = strings.Replace(rt, "task", "", 1)
+		pt, err := timestr.Parse(preRt)
+		if err != nil {
+			return "", err
+		}
+		rt, err = timestr.ModifyTime(rt, pt)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// when input layout is "+1h3m" or "now+1h3m"
+	if strings.HasPrefix(rt, "+") || strings.HasPrefix(rt, "now+") {
+		rt = strings.Replace(rt, "now", "", 1)
+		var err error
+		rt, err = timestr.ModifyTime(rt, time.Now())
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return timestr.UnifyLayout(rt)
+}

--- a/internal/entities/timestr/timestr.go
+++ b/internal/entities/timestr/timestr.go
@@ -11,6 +11,10 @@ const (
 )
 
 // UnifyLayout is a function that validates input and returns layoutMin type object.
+// Allowed layouts are
+//     "2006/1/2 15:04"
+//     "2006/1/2"
+// Transfer "2006/1/2" to "2006/1/2 15:04".
 func UnifyLayout(str string) (string, error) {
 	tm, errM := time.ParseInLocation(layoutMin, str, time.Local)
 	td, errD := time.ParseInLocation(layoutDay, str, time.Local)
@@ -31,24 +35,21 @@ func FormatTime(t time.Time) string {
 	return t.Format(layoutMin)
 }
 
-// ModifyTime is a function that modifies time.
-func ModifyTime(duration string, base string) (string, error) {
+// ModifyTime is a function that add duration to base time.
+func ModifyTime(duration string, base time.Time) (string, error) {
 	rt, err := time.ParseDuration(duration)
 
 	if err != nil {
 		return "", err
 	}
 
-	bt, err := time.ParseInLocation(layoutMin, base, time.Local)
-
-	if err != nil {
-		return "", err
-	}
-
-	return bt.Add(rt).Format(layoutMin), nil
+	return base.Add(rt).Format(layoutMin), nil
 }
 
 // Parse is a function that parse time.
+// Allowed layouts are
+//     "2006/1/2 15:04"
+//     "2006/1/2"
 func Parse(str string) (time.Time, error) {
 	tM, errM := time.ParseInLocation(layoutMin, str, time.Local)
 	tD, errD := time.ParseInLocation(layoutDay, str, time.Local)

--- a/internal/entities/timestr/timestr.go
+++ b/internal/entities/timestr/timestr.go
@@ -12,19 +12,15 @@ const (
 
 // UnifyLayout is a function that validates input and returns layoutMin type object.
 func UnifyLayout(str string) (string, error) {
-	if str == "" {
-		return "", nil
-	}
-
-	_, errM := time.ParseInLocation(layoutMin, str, time.Local)
-	_, errD := time.ParseInLocation(layoutDay, str, time.Local)
+	tm, errM := time.ParseInLocation(layoutMin, str, time.Local)
+	td, errD := time.ParseInLocation(layoutDay, str, time.Local)
 
 	if errM != nil && errD != nil {
 		return "", fmt.Errorf("invalid time layout: [minutes layout]: %s, [day layout]: %s", errM.Error(), errD.Error())
 	} else if errM == nil && errD != nil {
-		return str, nil
+		return tm.Format(layoutMin), nil
 	} else if errM != nil && errD == nil {
-		return str + " 00:00", nil
+		return td.Format(layoutMin), nil
 	}
 
 	return "", fmt.Errorf("Parse failed for some reason")

--- a/internal/entities/timestr/timestr.go
+++ b/internal/entities/timestr/timestr.go
@@ -30,11 +30,6 @@ func UnifyLayout(str string) (string, error) {
 	return "", fmt.Errorf("Parse failed for some reason")
 }
 
-// FormatTime is a function that formats time.
-func FormatTime(t time.Time) string {
-	return t.Format(layoutMin)
-}
-
 // ModifyTime is a function that add duration to base time.
 func ModifyTime(duration string, base time.Time) (string, error) {
 	rt, err := time.ParseDuration(duration)

--- a/internal/entities/timestr/timestr_test.go
+++ b/internal/entities/timestr/timestr_test.go
@@ -48,14 +48,13 @@ func TestModifyTime(t *testing.T) {
 	tests := []struct {
 		name      string
 		duration  string
-		base      string
+		base      time.Time
 		want      string
 		wantError bool
 		err       error
 	}{
-		{"Success", "1h1m", "2020/1/4 02:09", "2020/1/4 03:10", false, nil},
-		{"HasErrorInvalidDuration", "+1D1h1m", "2020/1/4 02:09", "", true, errors.New("time: unknown unit \"D\" in duration \"+1D1h1m\"")},
-		{"HasErrorInvalidBasetime", "1h", "invalid layout", "", true, errors.New("parsing time \"invalid layout\" as \"2006/1/2 15:04\": cannot parse \"invalid layout\" as \"2006\"")},
+		{"Success", "1h1m", time.Date(2020, 1, 4, 2, 9, 0, 0, time.Local), "2020/1/4 03:10", false, nil},
+		{"HasErrorInvalidDuration", "+1D1h1m", time.Date(2020, 1, 4, 3, 10, 0, 0, time.Local), "", true, errors.New("time: unknown unit \"D\" in duration \"+1D1h1m\"")},
 	}
 
 	for _, tt := range tests {

--- a/internal/entities/timestr/timestr_test.go
+++ b/internal/entities/timestr/timestr_test.go
@@ -16,9 +16,9 @@ func TestUnifyLayout(t *testing.T) {
 		wantError bool
 		err       error
 	}{
-		{"SuccessMinutesZeroPadding", "2020/12/04 23:29", "2020/12/04 23:29", false, nil},
+		{"SuccessMinutesZeroPadding", "2020/12/04 23:29", "2020/12/4 23:29", false, nil},
 		{"SuccessDay", "2020/1/4", "2020/1/4 00:00", false, nil},
-		{"SuccessDayZeroPadding", "2020/12/04", "2020/12/04 00:00", false, nil},
+		{"SuccessDayZeroPadding", "2020/12/04", "2020/12/4 00:00", false, nil},
 		{"HasErrorInvalidLayout", "invalid layout", "", true, errors.New("invalid time layout: [minutes layout]: parsing time \"invalid layout\" as \"2006/1/2 15:04\": cannot parse \"invalid layout\" as \"2006\", [day layout]: parsing time \"invalid layout\" as \"2006/1/2\": cannot parse \"invalid layout\" as \"2006\"")},
 	}
 


### PR DESCRIPTION
# チケット
#48 

# 概要
- timestrに関してformatを外で行うより、parseを外で行った方がきれいに行くのでは？と思ったため、そっちに変更した
- modifyの上書き処理に関してreminder部分がわかりづらかったので、 `remove-reminder` を追加した
- addとmodifyで時間の調整に似たような処理をしていたので共通化した
