### PR TITLE
バージョニングを追加しtagとreleaseを作成

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    branches: [ master ]
+    paths: ['CHANGELOG.md']
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out
+      uses: actions/checkout@v2
+
+    - name: Extract Version
+      id: version
+      run: |
+        VERSION=$(head -1 CHANGELOG.md | sed -e 's/^.*Version //g')
+        PRETAG=$(git tag | tail -1)
+        CHANGELOG=$(git diff $PRETAG CHANGELOG.md | grep -E '^\+' | grep -v '+++' | sed -e 's/^\+//g')
+        echo ::set-output name=version::$VERSION
+        echo ::set-output name=changelog::$CHANGELOG
+
+    - name: Tag
+      id: tag_version
+      uses: mathieudutour/github-tag-action@v5.2
+      with:
+        custom_tag: v${{ steps.version.outputs.version }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          CHANGELOG.md
+          LICENSE
+        tag_name: ${{ steps.tag_version.outputs.new_tag }}
+        body: ${{ steps.version.outputs.changelog }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## Version 0.0.1
+* initial application version


### PR DESCRIPTION
# チケット
なし

# 概要
リリースフロー等を考える際に
変更履歴
git tag
release
あたりが必要そうだったのでそれらを整備した。
