### PR TITLE
Add dependency in Makefile for calling build before testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,11 @@ mockgen: ## generate mock
 	$(GOGEN) ./...
 
 .PHONY: test
-test: ## go test
+test: build ## go test
 	$(GOTEST) -v ./...
 
 .PHONY: scenario-test
-scenario-test: ## run scenario test
+scenario-test: build ## run scenario test
 	$(GOTEST) -v $(SCENARIO_DIR) -tags scenario
 
 .PHONY: clean


### PR DESCRIPTION
# チケット
N/A
# 概要
When codes are changed and tests are executed, build must be called first.
I added that dependency in Makefile.