### PR TITLE
list表示の一行の長さを変更できるように修正

### DIFF
--- a/pkg/commands/configure.go
+++ b/pkg/commands/configure.go
@@ -24,6 +24,7 @@ func init() {
 	configureCmd.Flags().String("task_file_path", "", "the absolute path of your task json file. if not exist, create new directories and a file at the given path.")
 	configureCmd.Flags().String("slack_webhook_url", "", "slack webhookURL which can be gotten from Incoming Webhook")
 	configureCmd.Flags().String("slack_mention_to", "", "member ID of you if you want to be mentioned to in slack message")
+	configureCmd.Flags().Int("column_width", 30, "default column width")
 	configureCmd.Flags().Bool("reset_config", false, "reset config to default")
 	configureCmd.Flags().Bool("show_config", false, "show your config after setting up given change")
 }
@@ -71,6 +72,14 @@ func configureHandler(c *cobra.Command, args []string) error {
 			return err
 		}
 		viper.Set("SlackMentionTo", f)
+	}
+
+	if c.Flags().Changed("column_width") {
+		f, err := c.Flags().GetInt("column_width")
+		if err != nil {
+			return err
+		}
+		viper.Set("ColumnWidth", f)
 	}
 
 	if c.Flags().Changed("reset_config") {

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -33,6 +33,7 @@ func initConfig() {
 	viper.SetDefault("TaskFilePath", usecases.DefaultConfig.TaskFilePath)
 	viper.SetDefault("SlackWebhookURL", usecases.DefaultConfig.SlackWebhookURL)
 	viper.SetDefault("SlackMentionTo", usecases.DefaultConfig.SlackMentionTo)
+	viper.SetDefault("ColumnWidth", usecases.DefaultConfig.ColumnWidth)
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {

--- a/pkg/usecases/configure.go
+++ b/pkg/usecases/configure.go
@@ -13,6 +13,7 @@ type Config struct {
 	TaskFilePath    string
 	SlackWebhookURL string
 	SlackMentionTo  string
+	ColumnWidth     int
 }
 
 // ConfigFile is information of config file location.
@@ -29,6 +30,7 @@ var DefaultConfig = Config{
 	TaskFilePath:    filepath.Join(findDataDir(), "todo.json"),
 	SlackWebhookURL: "",
 	SlackMentionTo:  "",
+	ColumnWidth:     30,
 }
 
 // config is a protected member in usecases, which is readable from the other usecases.

--- a/pkg/usecases/list.go
+++ b/pkg/usecases/list.go
@@ -25,6 +25,7 @@ func List() error {
 
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetAutoFormatHeaders(false) // for preventing header from being made upper case automatically
+	table.SetColWidth(config.ColumnWidth)
 
 	header := columns{
 		id:         "ID",


### PR DESCRIPTION
# チケット
なし

# 概要
listの表示がすぐに折り返してしまっていたので、修正しました。

```
$ ./todo l
+----+--------------------------------+------------+----------+
| ID |              Task              | RemindTime | Priority |
+----+--------------------------------+------------+----------+
|  1 | hoge                           |            |      100 |
|  2 | 0123456789 0123456789          |            |      100 |
|    | 0123456789 0123456789          |            |          |
|    |                     0123456789 |            |          |
+----+--------------------------------+------------+----------+

$ ./todo conf --column_width=100

$ ./todo l
+----+--------------------------------------------------------+------------+----------+
| ID |                          Task                          | RemindTime | Priority |
+----+--------------------------------------------------------+------------+----------+
|  1 | hoge                                                   |            |      100 |
|  2 | 0123456789 0123456789 0123456789 0123456789 0123456789 |            |      100 |
+----+--------------------------------------------------------+------------+----------+
```