### PR TITLE
Add --hide_remind_time option in configure

### DIFF
--- a/pkg/commands/configure.go
+++ b/pkg/commands/configure.go
@@ -21,6 +21,7 @@ func init() {
 
 	configureCmd.Flags().Bool("hide_group", false, "hide a group column when show a list")
 	configureCmd.Flags().Bool("hide_reminder", false, "hide a reminder column when show a list")
+	configureCmd.Flags().Bool("hide_remind_time", false, "hide a remind time column when show a list")
 	configureCmd.Flags().Bool("hide_priority", false, "hide a priority column when show a list")
 	configureCmd.Flags().String("task_file_path", "", "the absolute path of your task json file. if not exist, create new directories and a file at the given path.")
 	configureCmd.Flags().String("slack_webhook_url", "", "slack webhookURL which can be gotten from Incoming Webhook")
@@ -46,6 +47,14 @@ func configureHandler(c *cobra.Command, args []string) error {
 			return err
 		}
 		viper.Set("HideReminder", f)
+	}
+
+	if c.Flags().Changed("hide_remind_time") {
+		f, err := c.Flags().GetBool("hide_remind_time")
+		if err != nil {
+			return err
+		}
+		viper.Set("HideRemindTime", f)
 	}
 
 	if c.Flags().Changed("hide_priority") {
@@ -100,6 +109,7 @@ func configureHandler(c *cobra.Command, args []string) error {
 		if f {
 			viper.Set("HideGroup", usecases.DefaultConfig.HideGroup)
 			viper.Set("HideReminder", usecases.DefaultConfig.HideReminder)
+			viper.Set("HideRemindTime", usecases.DefaultConfig.HideRemindTime)
 			viper.Set("HidePriority", usecases.DefaultConfig.HidePriority)
 			viper.Set("TaskFilePath", usecases.DefaultConfig.TaskFilePath)
 			viper.Set("SlackWebhookURL", usecases.DefaultConfig.SlackWebhookURL)

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -29,6 +29,7 @@ func initConfig() {
 	viper.AddConfigPath(c.ConfigPath)
 
 	viper.SetDefault("HideReminder", usecases.DefaultConfig.HideReminder)
+	viper.SetDefault("HideRemindTime", usecases.DefaultConfig.HideRemindTime)
 	viper.SetDefault("HidePriority", usecases.DefaultConfig.HidePriority)
 	viper.SetDefault("HideGroup", usecases.DefaultConfig.HideGroup)
 	viper.SetDefault("TaskFilePath", usecases.DefaultConfig.TaskFilePath)

--- a/pkg/usecases/configure.go
+++ b/pkg/usecases/configure.go
@@ -9,6 +9,7 @@ import (
 // Config is an application configuration.
 type Config struct {
 	HideReminder    bool
+	HideRemindTime  bool
 	HidePriority    bool
 	HideGroup       bool
 	TaskFilePath    string
@@ -27,6 +28,7 @@ type ConfigFile struct {
 // DefaultConfig is a default config.
 var DefaultConfig = Config{
 	HideReminder:    false,
+	HideRemindTime:  false,
 	HidePriority:    false,
 	HideGroup:       false,
 	TaskFilePath:    filepath.Join(findDataDir(), "todo.json"),

--- a/pkg/usecases/list.go
+++ b/pkg/usecases/list.go
@@ -63,7 +63,11 @@ func List(group string) error {
 // buildColumnAccordingToSetting build a row of table according to hide-setting.
 // this function define column order.
 func buildRowAccordingToConfig(row columns) []string {
-	builtRow := []string{row.id, row.task, row.remindTime}
+	builtRow := []string{row.id, row.task}
+
+	if !config.HideRemindTime {
+		builtRow = append(builtRow, row.remindTime)
+	}
 
 	if !config.HideGroup {
 		builtRow = append(builtRow, row.group)

--- a/test/scenario/crud_test.go
+++ b/test/scenario/crud_test.go
@@ -168,7 +168,7 @@ func TestWithoutReminder(t *testing.T) {
 		},
 		{
 			name:      "config Hide",
-			command:   []string{"conf", "--hide_group=true", "--hide_reminder=true", "--hide_priority=true"},
+			command:   []string{"conf", "--hide_remind_time=true", "--hide_group=true", "--hide_reminder=true", "--hide_priority=true"},
 			hasOutput: false,
 			want:      "",
 			wantError: false,
@@ -178,17 +178,17 @@ func TestWithoutReminder(t *testing.T) {
 			name:      "list hided tasks",
 			command:   []string{"l"},
 			hasOutput: true,
-			want: `+----+--------------------------------+----------------+
-| ID |              Task              |   RemindTime   |
-+----+--------------------------------+----------------+
-|  1 | deleting or modifying this     | 2099/1/1 00:00 |
-|    | task is your first TODO        |                |
-|  2 | scenario test 6                |                |
-|  3 | scenario test modified 1       | 2099/1/1 12:00 |
-|  4 | scenario test 2                | 2099/1/1 00:00 |
-|  5 | シナリオテスト 7               |                |
-|  6 | シナリオテスト 8               |                |
-+----+--------------------------------+----------------+
+			want: `+----+--------------------------------+
+| ID |              Task              |
++----+--------------------------------+
+|  1 | deleting or modifying this     |
+|    | task is your first TODO        |
+|  2 | scenario test 6                |
+|  3 | scenario test modified 1       |
+|  4 | scenario test 2                |
+|  5 | シナリオテスト 7               |
+|  6 | シナリオテスト 8               |
++----+--------------------------------+
 `,
 			wantError: false,
 			err:       "",


### PR DESCRIPTION
# チケット
N/A (I thought this P/R is a slight change. I open an issue if needed)
# 概要
To hide `RemindTime` column, `--hide_remind_time` option is implemented.

```bash
$ todo l
+----+--------------------------+----------------+-------+----------+----------+
| ID |           Task           |   RemindTime   | Group | Reminder | Priority |
+----+--------------------------+----------------+-------+----------+----------+
|  1 | scenario test 6          |                |       |          |       50 |
|  2 | test                     |                |       |          |      100 |
|  3 | scenario test modified 1 | 2099/1/1 12:00 |       |          |      100 |
|  4 | scenario test 2          | 2099/1/1 00:00 |       | macos    |      100 |
|  5 | シナリオテスト 7         |                |       |          |      100 |
|  6 | シナリオテスト 8         |                |       |          |      100 |
+----+--------------------------+----------------+-------+----------+----------+

$ todo conf --hide_remind_time=true

$ todo l
+----+--------------------------+-------+----------+----------+
| ID |           Task           | Group | Reminder | Priority |
+----+--------------------------+-------+----------+----------+
|  1 | scenario test 6          |       |          |       50 |
|  2 | test                     |       |          |      100 |
|  3 | scenario test modified 1 |       |          |      100 |
|  4 | scenario test 2          |       | macos    |      100 |
|  5 | シナリオテスト 7         |       |          |      100 |
|  6 | シナリオテスト 8         |       |          |      100 |
+----+--------------------------+-------+----------+----------+

$ todo conf --hide_remind_time=false

$ todo l
+----+--------------------------+----------------+-------+----------+----------+
| ID |           Task           |   RemindTime   | Group | Reminder | Priority |
+----+--------------------------+----------------+-------+----------+----------+
|  1 | scenario test 6          |                |       |          |       50 |
|  2 | test                     |                |       |          |      100 |
|  3 | scenario test modified 1 | 2099/1/1 12:00 |       |          |      100 |
|  4 | scenario test 2          | 2099/1/1 00:00 |       | macos    |      100 |
|  5 | シナリオテスト 7         |                |       |          |      100 |
|  6 | シナリオテスト 8         |                |       |          |      100 |
+----+--------------------------+----------------+-------+----------+----------+