### PR TITLE
conf --task_file_path be able to specify not exist file path

### DIFF
--- a/pkg/usecases/configure.go
+++ b/pkg/usecases/configure.go
@@ -102,8 +102,10 @@ func ValidateTaskFilePath(path string) error {
 			return err
 		}
 	}
-	if fInfo.IsDir() {
-		return fmt.Errorf("%s is a directory", path)
+	if fInfo != nil {
+		if fInfo.IsDir() {
+			return fmt.Errorf("%s is a directory", path)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
```
todo conf --task_file_path="/not/exist/file"
```

Above command occur panic.
I fixed it.